### PR TITLE
Add toolbar buttons to edit pages/great issues in github

### DIFF
--- a/book.json
+++ b/book.json
@@ -5,10 +5,10 @@
         "richquotes",
         "page-toc-button",
         "collapsible-menu",
-        "github",
         "language-picker",
         "language-redirect@git+https://github.com/hamishwillee/gitbook-plugin-language-redirect.git",
-        "custom-favicon"
+        "custom-favicon",
+        "toolbar@git+https://github.com/hamishwillee/gitbook-plugin-toolbar.git"
     ],
     "pluginsConfig": {       
         "language-redirect": {
@@ -21,10 +21,31 @@
                 "picto": "fa-thumbs-o-up"
             }
         },
-        "github": {
-            "url": "https://github.com/mavlink/qgc-dev-guide"
-        },
-        "favicon": "favicon.ico"
+        "favicon": "favicon.ico",
+        "toolbar": {
+            "buttons":
+            [
+                {
+                    "label": "Bug tracker",
+                    "icon": "fa fa-bug",
+                    "position" : "left",
+                    "url": "https://github.com/mavlink/qgc-dev-guide/issues/new?title=Doc+Bug:+{{title}}&body=DESCRIBE+PROBLEM+WITH+DOCS+HERE%0A%0ABug+Page:+[{{title}}]({{url}})"
+                    
+                },
+                {
+                    "label": "GitHub",
+                    "icon": "fa fa-github",
+                    "url": "https://github.com/mavlink/qgc-dev-guide"
+                },
+                {
+                    "label": "Edit page on github",
+                    "icon": "fa fa-pencil-square-o",
+                    "position" : "left",
+                    "url": "https://github.com/mavlink/qgc-dev-guide/edit/master/{{filepath_lang}}"
+                }
+            ]
+        }
+        
         
     } 
 


### PR DESCRIPTION
This makes it easier for users to report bugs in documents and to make small edits to documentation (larger edits your really need to do a build/test cycle, but this allows you to do quick updates in github of existing pages).

For more info see https://github.com/PX4/Devguide/pull/137