### PR TITLE
Sidebar: Enable Developer Call

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -35,6 +35,7 @@
      * [Fly View Customization](custom_build/FlyView.md)
   * [Release/Branching Process For Custom Builds](custom_build/ReleaseBranchingProcess.md)
 * [Code Submission](contribute/README.md)
+  * [Developer Call](contribute/dev_call.md)
   * [Coding Style](contribute/coding_style.md)
   * [Unit Tests](contribute/unit_tests.md)
   * [Pull Requests](contribute/pull_requests.md)


### PR DESCRIPTION
I can't remember exactly how this works in Gitbook, but I was missing the link on the sidebar, and that caused the main render pipeline to miss the new pages I created in #119

