### PR TITLE
Containers: new build system based on containers

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -1,7 +1,8 @@
 # Summary
 
 * [Overview](README.md)
-* [Getting Started](getting_started/README.md)
+* [Getting Started with source & builds)](getting_started/README.md)
+  * [Build using Containers](getting_started/container.md)
   * [Using QGC on CentOS](getting_started/CentOS.md)
 * [QGC Release/Branching Process](ReleaseBranchingProcess.md)
 * [Communication Flow](communication_flow.md)

--- a/en/getting_started/README.md
+++ b/en/getting_started/README.md
@@ -27,6 +27,11 @@ To get the source files:
 
 ## Build QGroundControl
 
+## Using Containers
+We support Linux builds using a container found on the source tree of the repository, which can help you develop and deploy the QGC apps without having to install any of the requirements on your local environment.
+
+[Container Guide](../getting_started/container.md)
+
 ### Native Builds
 
 *QGroundControl* builds are supported for macOS, Linux, Windows, iOS and Android. *QGroundControl* uses [Qt](http://www.qt.io) as its cross-platform support library and uses [QtCreator](http://doc.qt.io/qtcreator/index.html) as its default build environment.

--- a/en/getting_started/README.md
+++ b/en/getting_started/README.md
@@ -27,7 +27,7 @@ To get the source files:
 
 ## Build QGroundControl
 
-## Using Containers
+### Using Containers
 We support Linux builds using a container found on the source tree of the repository, which can help you develop and deploy the QGC apps without having to install any of the requirements on your local environment.
 
 [Container Guide](../getting_started/container.md)

--- a/en/getting_started/container.md
+++ b/en/getting_started/container.md
@@ -1,0 +1,28 @@
+# Building using Containers
+
+The community created a docker image that can help you build a Linux-based QGC application without much effort. This will give you a massive boost in productivity and help you with testing.
+
+## About the Container
+
+The Container is located in the `./deploy/container` directory. It's based on ubuntu 20.04. It pre-installs all the dependencies at build time, including Qt, thanks to a script located in the same directory, `install-qt-linux.sh`. The main advantage of using the Container is the usage of the `CMake` build system and its many improvements over `qmake`
+
+## Building the Container
+
+Before using the Container, you have to build the image. You can accomplish this using docker, running the following script from the root of the QGC source code directory.
+
+```
+docker build --file ./deploy/docker/Dockerfile-build-linux -t qgc-linux-docker .
+```
+
+> ::Note:: The `-t` flag is essential. Keep in mind this is tagging the image for later reference since you can have multiple builds of the same Container
+
+## Building QGC using the Container
+
+To use the Container to build QGC, you first need to define a directory to save the artifacts. We recommend you create a `build` directory on the source tree and then run the docker image using the tag provided above as follows, from the root directory:
+
+```
+mkdir build
+docker run --rm -v $PWD./project/source -v $PWD/build./project/build qgc-linux-docker
+```
+
+> ::Note:: Depending on your system resources, or the resources assigned to your Docker Daemon, this step can take some time.

--- a/en/getting_started/container.md
+++ b/en/getting_started/container.md
@@ -25,4 +25,4 @@ mkdir build
 docker run --rm -v $PWD./project/source -v $PWD/build./project/build qgc-linux-docker
 ```
 
-> ::Note:: Depending on your system resources, or the resources assigned to your Docker Daemon, this step can take some time.
+> **Note** Depending on your system resources, or the resources assigned to your Docker Daemon, this step can take some time.

--- a/en/getting_started/container.md
+++ b/en/getting_started/container.md
@@ -1,24 +1,31 @@
 # Building using Containers
 
-The community created a docker image that can help you build a Linux-based QGC application without much effort. This will give you a massive boost in productivity and help you with testing.
+The community created a docker image that makes it much easier to build a Linux-based QGC application.
+This can give you a massive boost in productivity and help with testing.
 
 ## About the Container
 
-The Container is located in the `./deploy/container` directory. It's based on ubuntu 20.04. It pre-installs all the dependencies at build time, including Qt, thanks to a script located in the same directory, `install-qt-linux.sh`. The main advantage of using the Container is the usage of the `CMake` build system and its many improvements over `qmake`
+The Container is located in the `./deploy/container` directory.
+It's based on ubuntu 20.04.
+It pre-installs all the dependencies at build time, including Qt, thanks to a script located in the same directory, `install-qt-linux.sh`.
+The main advantage of using the Container is the usage of the `CMake` build system and its many improvements over `qmake`
 
 ## Building the Container
 
-Before using the Container, you have to build the image. You can accomplish this using docker, running the following script from the root of the QGC source code directory.
+Before using the Container, you have to build the image.
+You can accomplish this using docker, running the following script from the root of the QGC source code directory.
 
 ```
 docker build --file ./deploy/docker/Dockerfile-build-linux -t qgc-linux-docker .
 ```
 
-> ::Note:: The `-t` flag is essential. Keep in mind this is tagging the image for later reference since you can have multiple builds of the same Container
+> **Note** The `-t` flag is essential.
+  Keep in mind this is tagging the image for later reference since you can have multiple builds of the same Container
 
 ## Building QGC using the Container
 
-To use the Container to build QGC, you first need to define a directory to save the artifacts. We recommend you create a `build` directory on the source tree and then run the docker image using the tag provided above as follows, from the root directory:
+To use the Container to build QGC, you first need to define a directory to save the artifacts.
+We recommend you create a `build` directory on the source tree and then run the docker image using the tag provided above as follows, from the root directory:
 
 ```
 mkdir build


### PR DESCRIPTION
documents how to use the new docker containers to build QGC apps
directly without having to install the requirements on your local
development machine.