### PR TITLE
Book.json: Update build to supported version of Qt

### DIFF
--- a/book.json
+++ b/book.json
@@ -4,7 +4,7 @@
     "variables": {
         "logo": "./assets/site/logo_qgc_rgb_horizontal.png",
         "qgc_version": "master",
-        "qt_version": "5.12.6"
+        "qt_version": "5.15.2"
     },
     "plugins": [
         "youtube",


### PR DESCRIPTION
Updates official qt build to 5.15.2. This is the final version of Qt before version 6, which is not yet supported by QGC.