### PR TITLE
Add info on how to customize mavlink

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -35,6 +35,7 @@
      * [Toolbar customization](custom_build/Toolbar.md)
      * [Fly View Customization](custom_build/FlyView.md)
   * [Release/Branching Process For Custom Builds](custom_build/ReleaseBranchingProcess.md)
+  * [MAVLink](custom_build/mavlink.md)
 * [Code Submission](contribute/README.md)
   * [Developer Call](contribute/dev_call.md)
   * [Coding Style](contribute/coding_style.md)

--- a/en/custom_build/mavlink.md
+++ b/en/custom_build/mavlink.md
@@ -1,0 +1,12 @@
+# MAVLink Customisation
+
+QGC communicates with flight stacks using [MAVLink](https://mavlink.io/en/), a very lightweight messaging protocol that has been designed for the drone ecosystem.
+QGC includes the [ArduPilotMega.xml](https://mavlink.io/en/messages/ardupilotmega.html) dialect by default, which allows it to communicate with both PX4 and Ardupilot (PX4 uses [common.xml](https://mavlink.io/en/messages/common.html), which is incuded in ArduPilotMega).
+
+In order to add support for a new set of messages you will ultimately need to add them to `ArduPilotMega.xml` or `common.xml`, or fork *QGroundControl* and include your own dialect.
+
+To do this:
+- Replace the pre-build C library at [/qgroundcontrol/libs/mavlink/include/mavlink](https://github.com/mavlink/qgroundcontrol/tree/master/libs/mavlink/include/mavlink).
+  - By default this is a submodule importing https://github.com/mavlink/c_library_v2
+  - You can change the submodule, or [build your own libraries](https://mavlink.io/en/getting_started/generate_libraries.html) using the MAVLink toolchain.
+- You can change the whole dialect used by setting it in [`MAVLINK_CONF`](https://github.com/mavlink/qgroundcontrol/blob/master/QGCExternalLibs.pri#L52) when running *qmake*.


### PR DESCRIPTION
This is something you might want to do in order to test new messages being added to a flight stack, or if you're customizing QGC for another flight stack and you want to update the whole dialect. I figured providing some hints might be useful.

@DonLakeFlyer Is this information:
- correct
- sufficient
- in the right place?

Is there a better way to do this?

