### PR TITLE
Added for Android Build, use Java version 11

### DIFF
--- a/en/getting_started/README.md
+++ b/en/getting_started/README.md
@@ -40,7 +40,7 @@ We support Linux builds using a container found on the source tree of the reposi
 - **Ubuntu:** 64 bit, gcc compiler
 - **Windows:** Vista or higher, [Visual Studio 2019 compiler](#vs) (64 bit)
 - **iOS:** 10.0 and higher
-- **Android:** Jelly Bean (4.1) and higher. Standard QGC is built against ndk version 19.
+- **Android:** Jelly Bean (4.1) and higher. Standard QGC is built against ndk version 19. Use Java JDK version 11 in Qt Creator to build
 - **Qt version:** {{ book.qt_version }} **(only)** <!-- NOTE {{ book.qt_version }} is set in the variables section of gitbook file https://github.com/mavlink/qgc-dev-guide/blob/master/book.json -->
   > **Warning** **Do not use any other version of Qt!**
     QGC has been thoroughly tested with the specified version of Qt ({{ book.qt_version }}).

--- a/en/getting_started/README.md
+++ b/en/getting_started/README.md
@@ -40,7 +40,7 @@ We support Linux builds using a container found on the source tree of the reposi
 - **Ubuntu:** 64 bit, gcc compiler
 - **Windows:** Vista or higher, [Visual Studio 2019 compiler](#vs) (64 bit)
 - **iOS:** 10.0 and higher
-- **Android:** Jelly Bean (4.1) and higher. Standard QGC is built against ndk version 19. Use Java JDK version 11 in Qt Creator to build
+- **Android:** Jelly Bean (4.1) and higher. Standard QGC is built against ndk version 19.
 - **Qt version:** {{ book.qt_version }} **(only)** <!-- NOTE {{ book.qt_version }} is set in the variables section of gitbook file https://github.com/mavlink/qgc-dev-guide/blob/master/book.json -->
   > **Warning** **Do not use any other version of Qt!**
     QGC has been thoroughly tested with the specified version of Qt ({{ book.qt_version }}).
@@ -90,6 +90,7 @@ To install Qt:
    - **Fedora:** `sudo dnf install speech-dispatcher SDL2-devel SDL2 systemd-devel patchelf`
    - **Arch Linux:** `pacman -Sy speech-dispatcher patchelf`
    - **Android:** [Qt Android Setup](http://doc.qt.io/qt-5/androidgs.html)
+     > **Note**: JDK11 is required (install if needed)!
 1. Install Optional/OS-Specific Functionality
 
    > **Note** Optional features that are dependent on the operating system and user-installed libraries are linked/described below.
@@ -102,12 +103,14 @@ To install Qt:
 #### Building using Qt Creator {#qt-creator}
 
 1. Launch *Qt Creator* and open the **qgroundcontrol.pro** project.
-1. Select the appropriate kit for your needs:
-  - **OSX:** Desktop Qt {{ book.qt_version }} clang 64 bit
-    > **Note** iOS builds must be built using [XCode](http://doc.qt.io/qt-5/ios-support.html).
-  - **Ubuntu:** Desktop Qt {{ book.qt_version }} GCC 64bit
-  - **Windows:** Desktop Qt {{ book.qt_version }} MSVC2019 **64bit**
-  - **Android:** Android for armeabi-v7a (GCC 4.9, Qt {{ book.qt_version }})
+1. In the **Projects** section, select the appropriate kit for your needs:
+   - **OSX:** Desktop Qt {{ book.qt_version }} clang 64 bit
+     > **Note** iOS builds must be built using [XCode](http://doc.qt.io/qt-5/ios-support.html).
+   - **Ubuntu:** Desktop Qt {{ book.qt_version }} GCC 64bit
+   - **Windows:** Desktop Qt {{ book.qt_version }} MSVC2019 **64bit**
+   - **Android:** Android for armeabi-v7a (GCC 4.9, Qt {{ book.qt_version }})
+1. (Android only) Confirm JDK11 is being used by reviewing the information in the _JDK location_ project setting (**Projects > Manage Kits > Devices > Android (tab) > Android Settings > JDK location**).
+   Update the location if necessary.
 1. Build using the "hammer" (or "play") icons:
 
    ![QtCreator Build Button](../../assets/getting_started/qt_creator_build_qgc.png)


### PR DESCRIPTION
While building the Android App with Java JDK version selected other than 11, the build would fail and gives java sdk error
Android build only finishes when java version 11 is selected in the Qt Creator Settings

It would be a great idea to have that info in the documentation, i.e. "to use java version 11 when building for android"