### PR TITLE
Add build-essential curl to Ubuntu dependencies

### DIFF
--- a/en/getting_started/README.md
+++ b/en/getting_started/README.md
@@ -86,7 +86,7 @@ To install Qt:
 
    ![QtCreator Select Components (Windows)](../../assets/getting_started/qt_creator_select_components.jpg)
 1. Install Additional Packages (Platform Specific)
-   - **Ubuntu:** `sudo apt-get install speech-dispatcher libudev-dev libsdl2-dev patchelf`
+   - **Ubuntu:** `sudo apt-get install speech-dispatcher libudev-dev libsdl2-dev patchelf build-essential curl`
    - **Fedora:** `sudo dnf install speech-dispatcher SDL2-devel SDL2 systemd-devel patchelf`
    - **Arch Linux:** `pacman -Sy speech-dispatcher patchelf`
    - **Android:** [Qt Android Setup](http://doc.qt.io/qt-5/androidgs.html)


### PR DESCRIPTION
Fixes #159 - allows airmap to build on ubuntu, or at least prevents failure during build.

Note that I have built this before and it worked, but I likely had those dependencies already present. I'm OK with this either way as they are needed, and if already installed there is no cost to it.