### PR TITLE
Updated "Getting Started with Source and Builds" Documentation

### DIFF
--- a/en/getting_started/README.md
+++ b/en/getting_started/README.md
@@ -121,9 +121,10 @@ To install Qt:
      > **Note** iOS builds must be built using [XCode](http://doc.qt.io/qt-5/ios-support.html).
    - **Ubuntu:** Desktop Qt {{ book.qt_version }} GCC 64bit
    - **Windows:** Desktop Qt {{ book.qt_version }} MSVC2019 **64bit**
-   - **Android:** Android for armeabi-v7a (GCC 4.9, Qt {{ book.qt_version }})
+   - **Android:** Android for Multi-Abi (GCC 4.9, Qt {{ book.qt_version }})
      - JDK11 is required.
        You can confirm it is being used by reviewing the project setting: **Projects > Manage Kits > Devices > Android (tab) > Android Settings > _JDK location_**.
+     - Supports **armv7a**, **x86**, **arm64-v8** and **x86_64** 
 1. Build using the "hammer" (or "play") icons:
 
    ![QtCreator Build Button](../../assets/getting_started/qt_creator_build_qgc.png)

--- a/en/getting_started/README.md
+++ b/en/getting_started/README.md
@@ -86,7 +86,7 @@ To install Qt:
    - **Linux**: *Desktop gcc 64-bit*
    - All:
      - *Qt Charts* <!-- and *Qt Remote Objects (TP)* -->
-     - *Android ARMv7* (optional, used to build Android)
+     - *Android* (optional, used to build Android)
 
    ![QtCreator Select Components (Windows)](../../assets/getting_started/qt_creator_select_components.jpg)
 1. Install Additional Packages (Platform Specific)


### PR DESCRIPTION
- Android build package on QT is now called Clang Multi-Abi rather than armeabi-v7a

- When installing package on QT, selector for android is now just called Android rather than Android ARMv7

- I decided it would be useful to mention what platforms Android can build for right under **Building using Qt Creator** under **Android**