### PR TITLE
Update README.md

### DIFF
--- a/en/getting_started/README.md
+++ b/en/getting_started/README.md
@@ -42,7 +42,7 @@ We support Linux builds using a container found on the source tree of the reposi
 - **Ubuntu:** 64 bit, gcc compiler
 - **Windows:** Vista or higher, [Visual Studio 2019 compiler](#vs) (64 bit)
 - **iOS:** 10.0 and higher
-- **Android:** Jelly Bean (4.1) and higher.
+- **Android:** Android 5.0 and later.
   - Standard QGC is built against ndk version 19.
   - Java JDK 11 is required.
 - **Qt version:** {{ book.qt_version }} **(only)** <!-- NOTE {{ book.qt_version }} is set in the variables section of gitbook file https://github.com/mavlink/qgc-dev-guide/blob/master/book.json -->


### PR DESCRIPTION
Updated Android version to match QT 5.15 LTS supported versions. https://doc.qt.io/qt-5/supported-platforms.html.

If this is incorrect and Android Jellybean is still supportable, please let me know and I'll add clarification